### PR TITLE
Open social links in new tab

### DIFF
--- a/components/SocialLink.tsx
+++ b/components/SocialLink.tsx
@@ -13,7 +13,7 @@ interface SocialLinkProps {
 }
 
 const SocialLink = ({ href, icon }: SocialLinkProps) => (
-  <a href={href} className={styles.socialButton}>
+  <a href={href} className={styles.socialButton} target='_blank'>
     <InlineIcon className={styles.icon} icon={icon} />
   </a>
 );


### PR DESCRIPTION
Keeping the original page open leads to a better user experience as they can return to the homepage easier